### PR TITLE
Changed code for bringing back most recent Miseq projects to use

### DIFF
--- a/lib/LIMS2/WebApp/Controller/User/PointMutation.pm
+++ b/lib/LIMS2/WebApp/Controller/User/PointMutation.pm
@@ -167,7 +167,10 @@ sub point_mutation_allele : Path('/user/point_mutation_allele') : Args(0) {
 sub browse_point_mutation : Path('/user/browse_point_mutation') : Args(0) {
     my ( $self, $c ) = @_;
 
-    my @miseqs = sort { $b->{date} cmp $a->{date} } map { $_->as_hash } $c->model('Golgi')->schema->resultset('MiseqProject')->search( { }, { rows => 15 } );
+    my @miseqs = $c->model('Golgi')->schema->resultset('MiseqProject')->search( { },
+        { order_by => { -desc => 'creation_date' },
+          rows => 10 }
+    );
     $c->stash(
         miseqs => \@miseqs,
     );

--- a/lib/LIMS2/WebApp/Controller/User/PointMutation.pm
+++ b/lib/LIMS2/WebApp/Controller/User/PointMutation.pm
@@ -167,7 +167,7 @@ sub point_mutation_allele : Path('/user/point_mutation_allele') : Args(0) {
 sub browse_point_mutation : Path('/user/browse_point_mutation') : Args(0) {
     my ( $self, $c ) = @_;
 
-    my @miseqs = $c->model('Golgi')->schema->resultset('MiseqProject')->search( { },
+    my @miseqs = map { $_->as_hash } $c->model('Golgi')->schema->resultset('MiseqProject')->search( { },
         { order_by => { -desc => 'creation_date' },
           rows => 10 }
     );


### PR DESCRIPTION
DBIx::Class order by

It's best practice to delegate sorting and searching to the underlying
database. This commit uses SQL abstract to request the database to
return the 20 most recent projects order by date. The original code
could not guarantee that this would happen as there was no order by on
the search statement. We also avoid havig to use Perl for the sort step.