### PR TITLE
Get assigned trivial when fetching exp details

### DIFF
--- a/lib/LIMS2/Report/EPPipelineIIPlate.pm
+++ b/lib/LIMS2/Report/EPPipelineIIPlate.pm
@@ -204,7 +204,7 @@ sub get_well_info {
     if (scalar @crispr_boxes) { $crispr_locs = join ",", @crispr_boxes; }
 
     ## get well experiment
-    my $db_exp = $self->model->schema->resultset( 'Experiment' )->find($info, { columns => [ qw/id gene_id/ ] });
+    my $db_exp = $self->model->schema->resultset( 'Experiment' )->find($info, { columns => [ qw/id gene_id assigned_trivial/ ] });
     $info->{experiment_id} = $db_exp->get_column('id');
     $info->{trivial_name} = $db_exp->trivial_name;
 


### PR DESCRIPTION
When the EP Pipeline II report requests experiment details it only grabs
a few columns (but still gets the joined trivial view).

This meant the trivial_name never sees the assigned trivial name, while
the trivial view is empty for experiments with assigned trivial names.