### PR TITLE
Miseq backfill required schema changes

### DIFF
--- a/ddl/versions/144/audit-up.sql
+++ b/ddl/versions/144/audit-up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE audit.miseq_experiment ADD COLUMN experiment_id integer;
+ALTER TABLE audit.miseq_experiment ADD COLUMN parent_plate_id integer;
+ALTER TABLE audit.miseq_experiment DROP COLUMN gene;

--- a/ddl/versions/144/audit-up.sql
+++ b/ddl/versions/144/audit-up.sql
@@ -1,3 +1,2 @@
 ALTER TABLE audit.miseq_experiment ADD COLUMN experiment_id integer;
 ALTER TABLE audit.miseq_experiment ADD COLUMN parent_plate_id integer;
-ALTER TABLE audit.miseq_experiment DROP COLUMN gene;

--- a/ddl/versions/144/fixtures.sql
+++ b/ddl/versions/144/fixtures.sql
@@ -1,0 +1,1 @@
+INSERT INTO schema_versions(version) VALUES (144);

--- a/ddl/versions/144/up.sql
+++ b/ddl/versions/144/up.sql
@@ -1,3 +1,2 @@
-ALTER TABLE miseq_experiment DROP COLUMN IF EXISTS gene;
 ALTER TABLE miseq_experiment ADD COLUMN experiment_id int REFERENCES experiments(id);
 ALTER TABLE miseq_experiment ADD COLUMN parent_plate_id int REFERENCES plates(id);

--- a/ddl/versions/144/up.sql
+++ b/ddl/versions/144/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE miseq_experiment DROP COLUMN IF EXISTS gene;
+ALTER TABLE miseq_experiment ADD COLUMN experiment_id int REFERENCES experiments(id);
+ALTER TABLE miseq_experiment ADD COLUMN parent_plate_id int REFERENCES plates(id);

--- a/lib/LIMS2/Model/Plugin/Miseq.pm
+++ b/lib/LIMS2/Model/Plugin/Miseq.pm
@@ -105,6 +105,8 @@ sub pspec_create_miseq_experiment {
         miseq_id        => { validate => 'existing_miseq_plate' },
         name            => { validate => 'non_empty_string' },
         gene            => { validate => 'non_empty_string' },
+        parent_plate_id => { validate => 'existing_plate_id', optional => 1 },
+        experiment_id   => { validate => 'existing_experiment_id', optional => 1 },
         mutation_reads  => { validate => 'integer' },
         total_reads     => { validate => 'integer' },
     };
@@ -120,7 +122,7 @@ sub create_miseq_experiment {
     my $miseq = $self->schema->resultset('MiseqExperiment')->create(
         {   slice_def(
                 $validated_params,
-                qw( miseq_id name gene mutation_reads total_reads )
+                qw( miseq_id name experiment_id parent_plate_id gene mutation_reads total_reads )
             )
         }
     );
@@ -133,6 +135,7 @@ sub pspec_update_miseq_experiment {
         id              => { validate => 'existing_miseq_experiment' },
         miseq_id        => { validate => 'existing_miseq_plate', optional => 1 },
         name            => { validate => 'non_empty_string', optional => 1 },
+        gene            => { validate => 'non_empty_string', optional => 1 },
         experiment_id   => { validate => 'existing_experiment_id', optional => 1 },
         parent_plate_id => { validate => 'existing_plate_id', optional => 1 },
         mutation_reads  => { validate => 'integer', optional => 1 },
@@ -153,6 +156,7 @@ sub update_miseq_experiment {
     my $class;
     $class->{miseq_id} = $validated_params->{miseq_id} || $hash_well->{miseq_id};
     $class->{name} = $validated_params->{name} || $hash_well->{name};
+    $class->{gene} = $validated_params->{gene} || $hash_well->{gene};
     $class->{experiment_id} = $validated_params->{experiment_id} || $hash_well->{experiment_id};
     $class->{parent_plate_id} = $validated_params->{parent_plate_id} || $hash_well->{parent_plate_id};
     $class->{mutation_reads} = $validated_params->{mutation_reads} || $hash_well->{nhej_count};

--- a/lib/LIMS2/Model/Plugin/Miseq.pm
+++ b/lib/LIMS2/Model/Plugin/Miseq.pm
@@ -133,7 +133,8 @@ sub pspec_update_miseq_experiment {
         id              => { validate => 'existing_miseq_experiment' },
         miseq_id        => { validate => 'existing_miseq_plate', optional => 1 },
         name            => { validate => 'non_empty_string', optional => 1 },
-        gene            => { validate => 'non_empty_string', optional => 1 },
+        experiment_id   => { validate => 'existing_experiment_id', optional => 1 },
+        parent_plate_id => { validate => 'existing_plate_id', optional => 1 },
         mutation_reads  => { validate => 'integer', optional => 1 },
         total_reads     => { validate => 'integer', optional => 1 },
     };
@@ -152,7 +153,8 @@ sub update_miseq_experiment {
     my $class;
     $class->{miseq_id} = $validated_params->{miseq_id} || $hash_well->{miseq_id};
     $class->{name} = $validated_params->{name} || $hash_well->{name};
-    $class->{gene} = $validated_params->{gene} || $hash_well->{gene};
+    $class->{experiment_id} = $validated_params->{experiment_id} || $hash_well->{experiment_id};
+    $class->{parent_plate_id} = $validated_params->{parent_plate_id} || $hash_well->{parent_plate_id};
     $class->{mutation_reads} = $validated_params->{mutation_reads} || $hash_well->{nhej_count};
     $class->{total_reads} = $validated_params->{total_reads} || $hash_well->{read_count};
     $class->{old_miseq_id} = $hash_well->{old_miseq_id};

--- a/lib/LIMS2/Model/Schema/Result/Experiment.pm
+++ b/lib/LIMS2/Model/Schema/Result/Experiment.pm
@@ -221,6 +221,21 @@ __PACKAGE__->belongs_to(
   },
 );
 
+=head2 miseq_experiments
+
+Type: has_many
+
+Related object: L<LIMS2::Model::Schema::Result::MiseqExperiment>
+
+=cut
+
+__PACKAGE__->has_many(
+  "miseq_experiments",
+  "LIMS2::Model::Schema::Result::MiseqExperiment",
+  { "foreign.experiment_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 project_experiments
 
 Type: has_many
@@ -257,8 +272,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07022 @ 2018-04-13 16:36:10
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:TNpeqj/Yy9aR/nYp6SNCUQ
+# Created by DBIx::Class::Schema::Loader v0.07022 @ 2018-09-04 15:49:07
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:H4uesntSRqggnsQ2DSKZtQ
 
 __PACKAGE__->has_one(
   'trivial',

--- a/lib/LIMS2/Model/Schema/Result/MiseqExperiment.pm
+++ b/lib/LIMS2/Model/Schema/Result/MiseqExperiment.pm
@@ -56,6 +56,11 @@ __PACKAGE__->table("miseq_experiment");
   data_type: 'text'
   is_nullable: 0
 
+=head2 gene
+
+  data_type: 'text'
+  is_nullable: 1
+
 =head2 mutation_reads
 
   data_type: 'integer'
@@ -98,6 +103,8 @@ __PACKAGE__->add_columns(
   { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
   "name",
   { data_type => "text", is_nullable => 0 },
+  "gene",
+  { data_type => "text", is_nullable => 1 },
   "mutation_reads",
   { data_type => "integer", is_nullable => 1 },
   "total_reads",
@@ -235,8 +242,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07022 @ 2018-09-05 10:40:22
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:P8dstq1L6lzFH8nihuzlxw
+# Created by DBIx::Class::Schema::Loader v0.07022 @ 2018-09-05 11:40:49
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:knIx/x0tVwTwtGQrvet+mA
 
 sub as_hash {
     my $self = shift;

--- a/lib/LIMS2/Model/Schema/Result/MiseqExperiment.pm
+++ b/lib/LIMS2/Model/Schema/Result/MiseqExperiment.pm
@@ -235,8 +235,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07022 @ 2018-09-04 15:49:07
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:RL9mhybL5mUddgqsAtk2iQ
+# Created by DBIx::Class::Schema::Loader v0.07022 @ 2018-09-05 10:40:22
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:P8dstq1L6lzFH8nihuzlxw
 
 sub as_hash {
     my $self = shift;
@@ -247,6 +247,7 @@ sub as_hash {
         name        => $self->name,
         experiment_id   => $self->experiment_id,
         parent_plate_id => $self->parent_plate_id,
+        gene        => $self->gene,
         nhej_count  => $self->mutation_reads,
         read_count  => $self->total_reads,
         old_miseq_id => $self->old_miseq_id, #TODO delete after migration

--- a/lib/LIMS2/Model/Schema/Result/Plate.pm
+++ b/lib/LIMS2/Model/Schema/Result/Plate.pm
@@ -229,6 +229,21 @@ __PACKAGE__->might_have(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 miseq_experiments
+
+Type: has_many
+
+Related object: L<LIMS2::Model::Schema::Result::MiseqExperiment>
+
+=cut
+
+__PACKAGE__->has_many(
+  "miseq_experiments",
+  "LIMS2::Model::Schema::Result::MiseqExperiment",
+  { "foreign.parent_plate_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 miseq_plates
 
 Type: has_many
@@ -325,8 +340,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07022 @ 2017-05-22 12:34:04
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:lkWpBnDdwOmcZpmE1htdnQ
+# Created by DBIx::Class::Schema::Loader v0.07022 @ 2018-09-04 15:49:07
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Si+PaSdv3PjcDls+uKZrcA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/LIMS2/WebApp/Controller/API/PointMutation.pm
+++ b/lib/LIMS2/WebApp/Controller/API/PointMutation.pm
@@ -210,7 +210,7 @@ sub miseq_exp_parent_GET {
 
     my @results;
     try {
-        @results = map { $_->parent_plate } $c->model('Golgi')->schema->resultset('MiseqExperiment')->search(
+        @results = map { $_->miseq_plate } $c->model('Golgi')->schema->resultset('MiseqExperiment')->search(
             {
                 'LOWER(gene)' => { 'LIKE' => '%' . $term . '%' },
             },


### PR DESCRIPTION
Few schema and plugin changess needed to link Miseq Experiments back to parent plates. This is in preparation for the backfill script