### PR TITLE
Well name to index fix

### DIFF
--- a/lib/LIMS2/Model/Util/Miseq.pm
+++ b/lib/LIMS2/Model/Util/Miseq.pm
@@ -120,7 +120,7 @@ sub wells_generator {
 
     if ($name_to_index) {
         my %well_indexes;
-        @well_indexes{@well_names} = (0..$#well_names);
+        @well_indexes{@well_names} = (1..$#well_names+1);
         return \%well_indexes;
     }
 


### PR DESCRIPTION
Fixed a bug where the wells generator for converting well name to index,
would return a wrong value(1 less than the correct value)