### PR TITLE
Redmine 12547/classification changes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+0.532     2019-04-03 14:31:49 Europe/London
+
+    Create well expansion process
+    Miseq design stranding fix
 0.531     2019-03-15 12:17:31 Europe/London
 
 0.530     2019-03-08 13:41:44 Europe/London

--- a/ddl/versions/150/fixtures.sql
+++ b/ddl/versions/150/fixtures.sql
@@ -1,4 +1,4 @@
-INSERT INTO schema_versions(id) VALUES(150);
+INSERT INTO schema_versions(version) VALUES(150);
 INSERT INTO miseq_classification (id) VALUES ('K/O Hom - 1 Allele');
 INSERT INTO miseq_classification (id) VALUES ('K/O Hom - 2 Allele');
 INSERT INTO miseq_classification (id) VALUES ('K/O Het');

--- a/ddl/versions/152/audit-up.sql
+++ b/ddl/versions/152/audit-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE audit.miseq_classification ADD COLUMN ordering INT;

--- a/ddl/versions/152/fixtures.sql
+++ b/ddl/versions/152/fixtures.sql
@@ -1,9 +1,11 @@
 INSERT INTO schema_versions (version) VALUES (152);
-INSERT INTO miseq_classification (id) VALUES ('K/O Hom');
-INSERT INTO miseq_classification (id) VALUES ('K/O Hom Compound');
-INSERT INTO miseq_classification (id) VALUES ('HDR Hom');
-INSERT INTO miseq_classification (id) VALUES ('HDR K/O');
-INSERT INTO miseq_classification (id) VALUES ('WT');
+INSERT INTO miseq_classification (id, ordering) VALUES ('K/O Hom', 5);
+INSERT INTO miseq_classification (id, ordering) VALUES ('K/O Hom Compound', 6);
+INSERT INTO miseq_classification (id, ordering) VALUES ('HDR Hom', 8);
+INSERT INTO miseq_classification (id, ordering) VALUES ('HDR K/O', 10);
+INSERT INTO miseq_classification (id, ordering) VALUES ('WT', 4);
+INSERT INTO miseq_classification (id, ordering) VALUES ('HDR Hemizygous', 11);
+INSERT INTO miseq_classification (id, ordering) VALUES ('K/O Hemizygous', 12);
 UPDATE miseq_well_experiment SET classification = 'K/O Hom' WHERE classification = 'K/O Hom - 1 Allele';
 UPDATE miseq_well_experiment SET classification = 'K/O Hom Compound' WHERE classification = 'K/O Hom - 2 Allele';
 UPDATE miseq_well_experiment SET classification = 'HDR Hom' WHERE classification = 'HDR Hom - 2 Allele';
@@ -22,12 +24,7 @@ DELETE FROM miseq_classification WHERE id = 'Wild Type';
 UPDATE miseq_classification SET ordering = 1 WHERE id = 'Not Called';
 UPDATE miseq_classification SET ordering = 2 WHERE id = 'Failed';
 UPDATE miseq_classification SET ordering = 3 WHERE id = 'Mixed';
-UPDATE miseq_classification SET ordering = 4 WHERE id = 'WT';
-UPDATE miseq_classification SET ordering = 5 WHERE id = 'K/O Hom';
-UPDATE miseq_classification SET ordering = 6 WHERE id = 'K/O Hom Compound';
 UPDATE miseq_classification SET ordering = 7 WHERE id = 'K/O Het';
-UPDATE miseq_classification SET ordering = 8 WHERE id = 'HDR Hom';
 UPDATE miseq_classification SET ordering = 9 WHERE id = 'HDR Het';
-UPDATE miseq_classification SET ordering = 10 WHERE id = 'HDR K/O';
 
 

--- a/ddl/versions/152/fixtures.sql
+++ b/ddl/versions/152/fixtures.sql
@@ -1,0 +1,33 @@
+INSERT INTO schema_versions (version) VALUES (152);
+INSERT INTO miseq_classification (id) VALUES ('K/O Hom');
+INSERT INTO miseq_classification (id) VALUES ('K/O Hom Compound');
+INSERT INTO miseq_classification (id) VALUES ('HDR Hom');
+INSERT INTO miseq_classification (id) VALUES ('HDR K/O');
+INSERT INTO miseq_classification (id) VALUES ('WT');
+UPDATE miseq_well_experiment SET classification = 'K/O Hom' WHERE classification = 'K/O Hom - 1 Allele';
+UPDATE miseq_well_experiment SET classification = 'K/O Hom Compound' WHERE classification = 'K/O Hom - 2 Allele';
+UPDATE miseq_well_experiment SET classification = 'HDR Hom' WHERE classification = 'HDR Hom - 2 Allele';
+UPDATE miseq_well_experiment SET classification = 'HDR Het' WHERE classification = 'HDR Hom - 1 Allele';
+UPDATE miseq_well_experiment SET classification = 'WT' WHERE classification = 'Wild Type';
+UPDATE miseq_project_well_exp SET classification = 'K/O Hom' WHERE classification = 'K/O Hom - 1 Allele';
+UPDATE miseq_project_well_exp SET classification = 'K/O Hom Compound' WHERE classification = 'K/O Hom - 2 Allele';
+UPDATE miseq_project_well_exp SET classification = 'HDR Hom' WHERE classification = 'HDR Hom - 2 Allele';
+UPDATE miseq_project_well_exp SET classification = 'HDR Het' WHERE classification = 'HDR Hom - 1 Allele';
+UPDATE miseq_project_well_exp SET classification = 'WT' WHERE classification = 'Wild Type';
+DELETE FROM miseq_classification WHERE id = 'K/O Hom - 1 Allele';
+DELETE FROM miseq_classification WHERE id = 'K/O Hom - 2 Allele';
+DELETE FROM miseq_classification WHERE id = 'HDR Hom - 2 Allele';
+DELETE FROM miseq_classification WHERE id = 'HDR Hom - 1 Allele';
+DELETE FROM miseq_classification WHERE id = 'Wild Type';
+UPDATE miseq_classification SET ordering = 1 WHERE id = 'Not Called';
+UPDATE miseq_classification SET ordering = 2 WHERE id = 'Failed';
+UPDATE miseq_classification SET ordering = 3 WHERE id = 'Mixed';
+UPDATE miseq_classification SET ordering = 4 WHERE id = 'WT';
+UPDATE miseq_classification SET ordering = 5 WHERE id = 'K/O Hom';
+UPDATE miseq_classification SET ordering = 6 WHERE id = 'K/O Hom Compound';
+UPDATE miseq_classification SET ordering = 7 WHERE id = 'K/O Het';
+UPDATE miseq_classification SET ordering = 8 WHERE id = 'HDR Hom';
+UPDATE miseq_classification SET ordering = 9 WHERE id = 'HDR Het';
+UPDATE miseq_classification SET ordering = 10 WHERE id = 'HDR K/O';
+
+

--- a/ddl/versions/152/up.sql
+++ b/ddl/versions/152/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE miseq_classification ADD COLUMN ordering INT;

--- a/lib/LIMS2/WebApp/Controller/User/PointMutation.pm
+++ b/lib/LIMS2/WebApp/Controller/User/PointMutation.pm
@@ -161,7 +161,7 @@ sub point_mutation_allele : Path('/user/point_mutation_allele') : Args(0) {
     };
 
     my @status = map { $_->id } $c->model('Golgi')->schema->resultset('MiseqStatus')->all;
-    my @classifications = map { $_->id } $c->model('Golgi')->schema->resultset('MiseqClassification')->all;
+    my @classifications = map { $_->id } $c->model('Golgi')->schema->resultset('MiseqClassification')->search(undef, { order_by => { -asc => 'ordering' } });
 
     if ($exp_sel) {
         $c->stash->{selection} = $exp_sel;

--- a/root/site/user/pointmutation/point_mutation_allele.tt
+++ b/root/site/user/pointmutation/point_mutation_allele.tt
@@ -293,6 +293,8 @@ input:checked + .slider:before {
                     <dt>HDR Hom</dt> <dd>Desired change (e.g. SNP) made on both alleles</dd>
                     <dt>HDR Het</dt> <dd>Desired change (e.g. SNP) made on one allele, no damage on second allele</dd>
                     <dt>HDR K/O</dt> <dd>Desired change (e.g. SNP) on one allele, frame-shifting in/del on the other</dd>
+                    <dt>HDR Hemizygous</dt> <dd>Desired change (e.g. SNP) on the only allele present (gene resides on X chromosome)</dd>
+                    <dt>K/O Hemizygous</dt> <dd>Frameshift damage on the only allele present (gene resides on X chromosome)</dd>
                 </dl>
             </div>
         </div>

--- a/root/site/user/pointmutation/point_mutation_allele.tt
+++ b/root/site/user/pointmutation/point_mutation_allele.tt
@@ -277,6 +277,24 @@ input:checked + .slider:before {
                     </select>
                 </form>
             </div>
+            <div class="btn-group dropdown">
+                <button class="btn btn-danger dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                    Help 
+                    <span class="sr-only">Toggle Dropdown</span>
+                </button>
+                <dl class="dropdown-menu" style="width: 500px;padding: 5px">
+                    <dt>Not Called</dt> <dd>No classification has been set</dd>
+                    <dt>Failed</dt> <dd>Failed to recover from thaw</dd>
+                    <dt>Mixed</dt> <dd>2 or more cell populations detected</dd>
+                    <dt>WT</dt> <dd>No damage to either allele</dd>
+                    <dt>K/O Hom</dt> <dd>Frameshift damage with the same in/del observed in both alleles</dd>
+                    <dt>K/O Hom Compound</dt> <dd>Frameshift damage with a different in/del on each allele</dd>
+                    <dt>K/O Het</dt> <dd>Frameshift damage to one allele, second allele remains undamaged</dd>
+                    <dt>HDR Hom</dt> <dd>Desired change (e.g. SNP) made on both alleles</dd>
+                    <dt>HDR Het</dt> <dd>Desired change (e.g. SNP) made on one allele, no damage on second allele</dd>
+                    <dt>HDR K/O</dt> <dd>Desired change (e.g. SNP) on one allele, frame-shifting in/del on the other</dd>
+                </dl>
+            </div>
         </div>
         <div class='genes [% experiment.id %]'></div>
         <div class="bars" id="bars[% experiment.id %]"></div>


### PR DESCRIPTION
Updated the classification options in the dropdown menu and added a help button with definitions for each on the point mutation alleles page.
I added an ordering column to the miseq_classifications table so the classifications are always displayed in the correct order.